### PR TITLE
Update the requirements list to include the mhi.psout library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly
 kaleido
 tsdownsample==0.1.3
 psutil
+mhi.psout


### PR DESCRIPTION
The mhi.psout library is required for the updated plotter script.