### PR TITLE
Update-plotter-script

### DIFF
--- a/plotter/plotter.py
+++ b/plotter/plotter.py
@@ -94,7 +94,7 @@ def mapResultFiles(config: ReadConfig) -> Dict[int, List[Result]]:
     for dir_ in config.simDataDirs:
         for file_ in listdir(dir_[1]):
             files.append((dir_[0], join(dir_[1], file_)))
-
+    
     results: Dict[int, List[Result]] = dict()
 
     for file in files:
@@ -196,8 +196,16 @@ def addResults(plots: List[go.Figure],
                     sigColumn = ('##' + splitSigName[0], splitSigName[1])
                 else:
                     sigColumn = rawSigName
-            else:
+            elif typ == ResultType.EMT_INF or typ == ResultType.EMT_CSV or typ == ResultType.EMT_ZIP:
+                # uses only the signal name - last part of the hierarchical signal name
+                rawSigName = rawSigName.split('\\')[-1]
                 sigColumn = rawSigName
+            elif typ == ResultType.EMT_PSOUT:
+                # uses the full hierarchical signal name
+                sigColumn = rawSigName
+            else:
+                print(f'File type: {typ} unknown')
+                
 
             displayName = f'{resultName}:{rawSigName.split(" ")[0]}'
 


### PR DESCRIPTION
Updated plotter.py so that hierarchical structured signal names are only used for .psout files, and not for .inf / .csv or .csv or compressed .csv files where signal names are uniquly specified in a flat structur