### PR TITLE
Corrected path on the setup example for PSCAD

### DIFF
--- a/setup_examples/MTB_Setup_Example.pswx
+++ b/setup_examples/MTB_Setup_Example.pswx
@@ -1,4 +1,4 @@
-<workspace name="MTB_Setup_Example" version="5.0.2" crc="56193709">
+<workspace name="MTB_Setup_Example" version="5.0.2" crc="122972569">
   <paramlist name="options">
     <param name="compile_save_enable" value="false" />
     <param name="autosave_interval" value="0" />
@@ -23,7 +23,7 @@
     <param name="runtime_canvas_lock" value="0" />
   </paramlist>
   <projects>
-    <project type="library" name="MTB" filepath=".\MTB.pslx" />
+    <project type="library" name="MTB" filepath="..\MTB.pslx" />
     <project type="project" name="SimpleSolarFarm" filepath=".\SimpleSolarFarm.pscx" />
   </projects>
   <simulations>

--- a/setup_examples/SimpleSolarFarm.pscx
+++ b/setup_examples/SimpleSolarFarm.pscx
@@ -22,7 +22,7 @@
     <param name="Warn" value="0" />
     <param name="Check" value="0" />
     <param name="description" value="" />
-    <param name="revisor" value="CVL, 1734098112" />
+    <param name="revisor" value="pzr, 1753795836" />
     <param name="architecture" value="windows" />
     <param name="Source" value="" />
     <param name="Debug" value="0" />
@@ -11755,7 +11755,7 @@ Based on "best practices" guidelines]]></Sticky>
         <grouping />
       </schematic>
     </Definition>
-    <Definition classid="UserCmpDefn" name="Main" group="" url="" version="" build="" crc="47265307" instances="1" key="" view="false" date="1734097686" id="1090741750">
+    <Definition classid="UserCmpDefn" name="Main" group="" url="" version="" build="" crc="13632129" instances="1" key="" view="false" date="1734097686" id="1090741750">
       <paramlist>
         <param name="Description" value="" />
       </paramlist>
@@ -12720,7 +12720,7 @@ Last update 2018-10-05]]></Sticky>
           <vertex x="90" y="0" />
         </Wire>
         <User classid="UserCmp" id="794614574" name="MTB:unit_meas" x="720" y="486" w="188" h="89" z="240" orient="0" defn="MTB:unit_meas" link="-1" q="4" disable="false">
-          <paramlist name="" link="-1" crc="67039371">
+          <paramlist name="" link="-1" crc="33277434">
             <param name="Name" value="$ALIAS_UM_9124$" />
             <param name="alias_str" value="unit_N" />
             <param name="sbase_mva" value="25" />
@@ -14984,16 +14984,16 @@ WARNING RMS voltage is measured only on 3 phase or single phase lines, Selection
   </List>
   <bookmarks />
   <List classid="Resource">
-    <Resource classid="SourceResource" id="1214470555" url=".\interface.f">
+    <Resource classid="SourceResource" id="1214470555" url="..\interface.f">
       <paramlist>
-        <param name="filepath" value=".\interface.f" />
+        <param name="filepath" value="..\interface.f" />
         <param name="copy_file" value="false" />
         <param name="include" value="true" />
       </paramlist>
     </Resource>
-    <Resource classid="ScriptResource" id="1745046477" url=".\execute_pscad.py">
+    <Resource classid="ScriptResource" id="1745046477" url="..\execute_pscad.py">
       <paramlist>
-        <param name="filepath" value=".\execute_pscad.py" />
+        <param name="filepath" value="..\execute_pscad.py" />
         <param name="copy_file" value="false" />
       </paramlist>
     </Resource>
@@ -15006,15 +15006,15 @@ WARNING RMS voltage is measured only on 3 phase or single phase lines, Selection
     </paramlist>
   </GlobalSubstitutions>
   <hierarchy>
-    <call link="2007676367" name="SimpleSolarFarm:Station" z="-1" view="false" instance="0">
+    <call link="1972851759" name="SimpleSolarFarm:Station" z="-1" view="false" instance="0">
       <call link="862326792" name="SimpleSolarFarm:Main" z="-1" view="true" instance="0">
         <call link="260935989" name="MTB:MTB" z="140" view="false" instance="0">
-          <call link="168397858" name="MTB:ThreePhaseCtrl" z="2260" view="false" instance="0" />
-          <call link="1075289416" name="MTB:PLL_seq_src" z="2360" view="false" instance="0">
+          <call link="168397858" name="MTB:ThreePhaseCtrl" z="2340" view="false" instance="0" />
+          <call link="1075289416" name="MTB:PLL_seq_src" z="2440" view="false" instance="0">
             <call link="212921357" name="MTB:PLL_ADAPTIVE_src" z="60" view="false" instance="0" />
             <call link="1690585494" name="MTB:PLL_ADAPTIVE_src" z="70" view="false" instance="1" />
           </call>
-          <call link="131918621" name="MTB:Fault" z="2970" view="false" instance="0" />
+          <call link="131918621" name="MTB:Fault" z="3050" view="false" instance="0" />
         </call>
         <call link="1955742872" name="SimpleSolarFarm:Simple_PPC" z="220" view="false" instance="0">
           <call link="338060630" name="SimpleSolarFarm:PI_AntiWindUp" z="410" view="false" instance="0" />
@@ -15033,7 +15033,7 @@ WARNING RMS voltage is measured only on 3 phase or single phase lines, Selection
           <call link="480962023" name="SimpleSolarFarm:PI_AntiWindUp" z="1960" view="false" instance="11" />
         </call>
         <call link="794614574" name="MTB:unit_meas" z="240" view="false" instance="0">
-          <call link="1517696666" name="MTB:PLL_seq" z="510" view="false" instance="0">
+          <call link="1517696666" name="MTB:PLL_seq" z="470" view="false" instance="0">
             <call link="1742400640" name="MTB:PLL_ADAPTIVE" z="60" view="false" instance="0" />
             <call link="1637378826" name="MTB:PLL_ADAPTIVE" z="70" view="false" instance="1" />
           </call>


### PR DESCRIPTION
The library path was wrong in the MTB_Setup_Example.pswx and when opening the workspace the MTB library (.pslx) was not loaded. Now it is corrected and it loads the MTB when opening the workspace.