### PR TITLE
Update requirements for Plotly and Kaleido so that it uses Kaleido v1 with a compatible Plotly version. Add Kaleido Chrome sync call in main function as Chrome is no longer included with Kaleido.

### DIFF
--- a/plotter/plotter.py
+++ b/plotter/plotter.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from plotly.subplots import make_subplots  # type: ignore
 import plotly.graph_objects as go  # type: ignore
+import kaleido
 from typing import List, Dict, Union, Tuple, Set
 from sampling_functions import downSample
 from threading import Thread, Lock
@@ -860,6 +861,7 @@ def create_html_plots(columns, plots, rank, rankName):
 def main() -> None:
     start_time = time.time()
     config = ReadConfig()
+    kaleido.get_chrome_sync() # Make sure Kaleido is able to find the Chrome executable or install it if not available
 
     print('Starting plotter main thread')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pandas
 openpyxl
 jinja2
-plotly
-kaleido
+plotly>=6.1.1
+kaleido>=1.0.1
 tsdownsample==0.1.3
 psutil
 mhi.psout


### PR DESCRIPTION
https://pypi.org/project/kaleido/