### PR TITLE
Pscad select version

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -44,7 +44,7 @@ Use legacy Unit measurement signal naming = True
 # Intel 15.0.148 (64-bit), Intel 15.0.7.287, Intel 15.0.7.287 (64-bit), etc.
 Fortran version = 
 # Workspace path when running "execute_pscad.py" from the command line
-Workspace = .\setup_examples\MTB_Setup_Example.pswx
+Workspace = ..\Solbakke.pswx
 
 [PowerFactory]
 # PowerFactory parallel task automation. 

--- a/config.ini
+++ b/config.ini
@@ -9,6 +9,8 @@ Export folder = export
 Python path = 
 
 [PSCAD]
+# The software version of PSCAD. Most common ones: 5.0.2 or 5.1.0
+PSCAD version = 5.1.0
 # Volley size is the number of simulations to be run in parallel (up to a maximum of 64, license dependent).
 # This should always be at least 1 less than the number of processors available.
 Volley = 8
@@ -42,7 +44,7 @@ Use legacy Unit measurement signal naming = True
 # Intel 15.0.148 (64-bit), Intel 15.0.7.287, Intel 15.0.7.287 (64-bit), etc.
 Fortran version = 
 # Workspace path when running "execute_pscad.py" from the command line
-Workspace = ..\Solbakke.pswx
+Workspace = .\setup_examples\MTB_Setup_Example.pswx
 
 [PowerFactory]
 # PowerFactory parallel task automation. 

--- a/execute_pscad.py
+++ b/execute_pscad.py
@@ -45,6 +45,7 @@ sheetPath = config.get('General', 'Casesheet path', fallback='testcases.xlsx').s
 exportPath = config.get('General', 'Export folder', fallback='export').strip()
 pythonPath = config.get('Python', 'Python path', fallback='').strip()
 volley = config.getint('PSCAD', 'Volley', fallback=16)
+PSCADVersion = config.get('PSCAD', 'PSCAD version').strip()
 traceAffinity = config.getboolean('PSCAD', 'Tracing', fallback=False)
 stateAnimation = config.getboolean('PSCAD', 'State animation', fallback=False)
 onlyInUseChannels = config.getboolean('PSCAD', 'Only in use channels', fallback=True)
@@ -98,8 +99,8 @@ def connectPSCAD() -> mhi.pscad.PSCAD:
 def startPSCAD():
    
     # Launch PSCAD
-    print('Starting PSCAD v5.0.2\n')
-    pscad = mhi.pscad.launch(version='5.0.2',
+    print('Starting PSCAD v'+PSCADVersion+'\n')
+    pscad = mhi.pscad.launch(version=PSCADVersion,
                              silence=True,
                              splash=False,
                              minimize=True,


### PR DESCRIPTION
## Summary

Added the feature for the user to select which PSCAD version they want to use with the MTB.

This is useful now since some months ago a new version of PSCAD was released: version 5.1.0. Many users will have both versions installed on their machine and this gives them the option to chose between them.

## Changes

- Updated the config file with a new parameter called "PSCAD version" and some description of it.
- Updated the execute_pscad.py file so that instead of always starting PSCAD 5.0.2 it will start whatever version entered on the config file.

## Testing

This was tested by entering these two values in the PSCAD version parameter on the config file:
5.0.2
5.1.0